### PR TITLE
remove default severity level to respect config

### DIFF
--- a/src/linter.ts
+++ b/src/linter.ts
@@ -126,7 +126,6 @@ export class PerlLinterProvider {
 
     private getCommandArguments(tempfilepath: string): string[] {
         return [
-            "--brutal",
             "--verbose",
             "%s~|~%l~|~%c~|~%m~|~%e~|~%p~||~%n",
             tempfilepath,


### PR DESCRIPTION
The former implementation always called perlcritic with the severity
level 'brutal'. This is not always wanted by every user - especially not
for users the start using perlcritic.

Furthermore, calling perlcritic with '--brutal' didn't respect the
severity set in perlcritic's configuration.

This commit just removes the hard wired '--brutal'.